### PR TITLE
Fix: the mod may throw ConcurrentModificationException when try to read or write the size of the replay file

### DIFF
--- a/src/main/kotlin/me/senseiwells/replay/util/SizedZipReplayFile.kt
+++ b/src/main/kotlin/me/senseiwells/replay/util/SizedZipReplayFile.kt
@@ -10,6 +10,7 @@ import java.io.File
 import java.io.OutputStream
 import java.util.*
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
@@ -21,7 +22,7 @@ class SizedZipReplayFile(
     out: File,
     cache: File = File(out.parentFile, out.name + ".cache")
 ): ZipReplayFile(ReplayStudio(), input, out, cache) {
-    private val entries = HashMap<String, MutableLong>()
+    private val entries = ConcurrentHashMap<String, MutableLong>()
 
     override fun write(entry: String): OutputStream {
         val mutable = MutableLong()


### PR DESCRIPTION
(Please forgive my poor English. If you cannot understand the following content, please ask me questions below.)

Hi there, earlier, I noticed that some players on my server seemed unable to re-enter the server normally after logging out. After investigating, I identified the problem with this mod: the ```SizedZipReplayFile.write``` method appears to be quite slow and seems to be executed in another thread. Consequently, when players try to re-join the server, the ```SizedZipReplayFile.entries``` experiences concurrent read and write issues, leading to the throwing of ```ConcurrentModificationException``` and preventing players from entering the server normally. Below are some error logs from my server:
```
java.util.ConcurrentModificationException: null
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1597) ~[?:?]
	at java.util.HashMap$ValueIterator.next(HashMap.java:1625) ~[?:?]
	at me.senseiwells.replay.util.SizedZipReplayFile.getRawFileSize(SizedZipReplayFile.kt:106) ~[ServerReplay-1.0.7+mc1.20.1.jar:?]
	at me.senseiwells.replay.recorder.ReplayRecorder.getRawRecordingSize(ReplayRecorder.kt:198) ~[ServerReplay-1.0.7+mc1.20.1.jar:?]
	at me.senseiwells.replay.recorder.ReplayRecorder.calculateAndCheckFileSize(ReplayRecorder.kt:395) ~[ServerReplay-1.0.7+mc1.20.1.jar:?]
	at me.senseiwells.replay.recorder.ReplayRecorder.record(ReplayRecorder.kt:157) ~[ServerReplay-1.0.7+mc1.20.1.jar:?]
	at me.senseiwells.replay.recorder.ReplayRecorder.afterLogin(ReplayRecorder.kt:271) ~[ServerReplay-1.0.7+mc1.20.1.jar:?]
	at net.minecraft.class_3324.handler$eco000$server-replay$onPlaceNewPlayer(class_3324.java:8515) ~[server-intermediary.jar:?]
...
```
and then, an exception will be thrown when this player try to join this server again:
```
java.lang.IllegalArgumentException: Player already has a recorder
	at me.senseiwells.replay.player.PlayerRecorders.create(PlayerRecorders.kt:29) ~[ServerReplay-1.0.7+mc1.20.1.jar:?]
	at me.senseiwells.replay.player.PlayerRecorders.create(PlayerRecorders.kt:23) ~[ServerReplay-1.0.7+mc1.20.1.jar:?]
	at net.minecraft.class_3324.handler$eco000$server-replay$onPlaceNewPlayer(class_3324.java:8513) ~[server-intermediary.jar:?]
	at net.minecraft.class_3324.method_14570(class_3324.java) ~[server-intermediary.jar:?]
	at net.minecraft.class_3248.method_33800(class_3248.java:131) ~[server-intermediary.jar:?]
	at net.minecraft.class_3248.method_14384(class_3248.java:118) ~[server-intermediary.jar:?]
	at net.minecraft.class_3248.redirect$dbc000$fabric-networking-api-v1$handlePlayerJoin(class_3248.java:563) ~[server-intermediary.jar:?]
...
```
In this case, I suggest changing `SizedZipReplayFile.entries` from the current `HashMap` to a thread-safe `ConcurrentHashMap`. This might be a simple idea to fix this bug. Although I haven't figured out why concurrency issues are occurring, and indeed this problem cannot be reproduced 100% of the time (though it does happen quite frequently on my server),